### PR TITLE
dagger: update to 0.18.8

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.18.6 v
+github.setup        dagger dagger 0.18.8 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  50817194d57b7ab62f28fbd13d97bb498d8512f6 \
-                            sha256  96f74fe60e909c35134fb5c4aa7db020ac2cd5d6538af607ec10c72a58eae00e \
-                            size    18753539
+        checksums           rmd160  5f48c2935ec16601924e77bf3355b0a4a9a6c271 \
+                            sha256  7876679156db57577ef3486c2c5d3f4029822f2a39be229ffb37a125e42f6b79 \
+                            size    19067710
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  fa67c5e3f5aca300be7a896160107f55e6e5750b \
-                            sha256  cc64126ea4555285a812fa826ad15feaa4e8c578ec2f6c8531875c47013fd51e \
-                            size    17927121
+        checksums           rmd160  d77ef859a04711b6c6779eebb36c5089ed553cc9 \
+                            sha256  de5963a4017d4eaf0425fb4b28132774ea494afd7fe01a4b3a747f2baa1cff81 \
+                            size    18172100
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

Update to the latest version.

###### Tested on

macOS 15.4.1 24E263 arm64
Command Line Tools 16.3.0.0.1.1742442376

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
