### PR TITLE
py-virtualenv: update to 20.33.0

### DIFF
--- a/python/py-virtualenv/Portfile
+++ b/python/py-virtualenv/Portfile
@@ -5,7 +5,7 @@ PortGroup           python 1.0
 PortGroup           select 1.0
 
 name                py-virtualenv
-version             20.32.0
+version             20.33.0
 revision            0
 
 categories-append   devel
@@ -20,9 +20,9 @@ long_description    virtualenv is a tool to create isolated Python \
 
 homepage            https://virtualenv.pypa.io
 
-checksums           rmd160  912e325503fa7d5ca5d7f63f40793e97bcf8aefa \
-                    sha256  886bf75cadfdc964674e6e33eb74d787dff31ca314ceace03ca5810620f4ecf0 \
-                    size    6076970
+checksums           rmd160  6e63944b340bde97c3877f2b6145034856089ff2 \
+                    sha256  47e0c0d2ef1801fce721708ccdf2a28b9403fa2307c3268aebd03225976f61d2 \
+                    size    6082069
 
 # keep Python version 2.7 here, other EOL Python versions can be removed
 # See <https://trac.macports.org/wiki/Python#VersionPolicy>


### PR DESCRIPTION
###### Tested on
macOS 15.5 24F74 arm64
Command Line Tools 16.4.0.0.1.1747106510e

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?
- [ ] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?