### PR TITLE
dagger: update to 0.18.15

### DIFF
--- a/devel/dagger/Portfile
+++ b/devel/dagger/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 PortGroup           github 1.0
 
-github.setup        dagger dagger 0.18.14 v
+github.setup        dagger dagger 0.18.15 v
 github.tarball_from releases
 revision            0
 
@@ -24,15 +24,15 @@ homepage            https://dagger.io
 switch ${build_arch} {
     x86_64 {
         distfiles           dagger_v${version}_darwin_amd64${extract.suffix}
-        checksums           rmd160  3c171f4ed3bc3acf2014103b430ecc7aafe0857d \
-                            sha256  880361e92842400f4b14ef4dc4eb05dd269ee4f7a18059871f1c4411b8ddea4c \
-                            size    19501498
+        checksums           rmd160  5ef783db733c5ba883118a4d1a6a16374dc46c6c \
+                            sha256  d03e4b60277f0a288bf9ef7a3f3af3554bed4635f2fe1c5edbe3daf2599d2757 \
+                            size    19513116
     }
     arm64 {
         distfiles           dagger_v${version}_darwin_arm64${extract.suffix}
-        checksums           rmd160  4df6567a11097cab5734535ba34d3b2b40c27304 \
-                            sha256  c8646f662b75caf7226b83d840cf7a31533801514b06c1ea7e35e3e456fc894e \
-                            size    18606440
+        checksums           rmd160  61ad51f183a76ce9ad143d7f2ae8da09a725706e \
+                            sha256  23efd7b8d4ad301a78777be62da945677f88c127629822e2bd246dad7804440f \
+                            size    18625949
     }
     default {
         known_fail  yes


### PR DESCRIPTION
#### Description

latest version

###### Tested on

macOS 15.6 24G84 arm64
Command Line Tools 16.4.0.0.1.1747106510

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?